### PR TITLE
Buzz version fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "kriswallsmith/buzz": "0.7"
+        "kriswallsmith/buzz": "~0.3"
     },
     "autoload": {
         "psr-0": { "Endroid": "src/" }

--- a/src/Endroid/Twitter/Twitter.php
+++ b/src/Endroid/Twitter/Twitter.php
@@ -69,7 +69,7 @@ class Twitter
      * @param string $method
      * @param string $format
      * @param array $parameters
-     * @return \Buzz\Response
+     * @return \Buzz\Message\Response
      */
     public function query($name, $method = 'GET', $format = 'json', $parameters = array())
     {


### PR DESCRIPTION
The specific version of Buzz this had as a dependency was quite dated, and was causing problems with other libraries. Error handling in Buzz was changed at 0.7, so a lot of other libraries specify 0.7+. There isn't anything here that is incompatible with 0.3+, so I have updated the dependency to make it as flexible as possible.

I also fixed a little error in a doctag to help with code completion.
