### PR TITLE
Adds application only authentication through the Token API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Register your application at http://apps.twitter.com/app
 
 use Endroid\Twitter\Twitter;
 
+// If you want to fetch the Twitter API with "application only" authentication, $accessToken and $accessTokenSecret are optional
 $twitter = new Twitter($consumerKey, $consumerSecret, $accessToken, $accessTokenSecret);
 
 // Retrieve the user's timeline

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Endroid\\Twitter\\": [ "src/", "tests/" ]
+            "Endroid\\Twitter\\": [ "src/" ],
+            "Endroid\\Twitter\\Tests\\": [ "tests/" ]
         }
     },
     "config": {

--- a/src/Exception/InvalidParametersException.php
+++ b/src/Exception/InvalidParametersException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Endroid\Twitter\Exception;
+
+class InvalidParametersException extends \Exception
+{
+}

--- a/src/Exception/InvalidResponseException.php
+++ b/src/Exception/InvalidResponseException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Endroid\Twitter\Exception;
+
+class InvalidResponseException extends \Exception
+{
+}

--- a/src/Exception/InvalidTokenTypeException.php
+++ b/src/Exception/InvalidTokenTypeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Endroid\Twitter\Exception;
+
+class InvalidTokenTypeException extends \Exception
+{
+}

--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -25,12 +25,12 @@ class Twitter
     /**
      * @var string
      */
-    const TOKEN_URL = self::BASE_URL.'/oauth2/token/';
+    const TOKEN_URL = '/oauth2/token/';
 
     /**
      * @var string
      */
-    protected $apiUrl = self::BASE_URL.'/1.1/';
+    protected $apiUrl;
 
     /**
      * @var string
@@ -77,11 +77,7 @@ class Twitter
         $this->consumerSecret = $consumerSecret;
         $this->accessToken = $accessToken;
         $this->accessTokenSecret = $accessTokenSecret;
-
-        if ($apiUrl) {
-            $this->apiUrl = $apiUrl;
-        }
-
+        $this->apiUrl = $apiUrl ?: self::BASE_URL.'/1.1/';
         $this->browser = new Browser(new Curl());
     }
 
@@ -209,7 +205,7 @@ class Twitter
             'Content-Type: application/x-www-form-urlencoded'
         );
 
-        $response = $this->call('POST', self::TOKEN_URL, $headers, 'grant_type=client_credentials');
+        $response = $this->call('POST', self::BASE_URL.self::TOKEN_URL, $headers, 'grant_type=client_credentials');
         $content = $response->getContent();
         $result = json_decode($content, true);
 

--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -11,13 +11,26 @@ namespace Endroid\Twitter;
 
 use Buzz\Browser;
 use Buzz\Client\Curl;
+use Endroid\Twitter\Exception\InvalidParametersException;
+use Endroid\Twitter\Exception\InvalidResponseException;
+use Endroid\Twitter\Exception\InvalidTokenTypeException;
 
 class Twitter
 {
+    /*
+     * @var string
+     */
+    const BASE_URL = 'https://api.twitter.com';
+
     /**
      * @var string
      */
-    protected $apiUrl = 'https://api.twitter.com/1.1/';
+    const TOKEN_URL = self::BASE_URL.'/oauth2/token/';
+
+    /**
+     * @var string
+     */
+    protected $apiUrl = self::BASE_URL.'/1.1/';
 
     /**
      * @var string
@@ -47,39 +60,35 @@ class Twitter
     /**
      * Class constructor.
      *
-     * @param $consumerKey
-     * @param $consumerSecret
-     * @param $accessToken
-     * @param $accessTokenSecret
+     * @param string      $consumerKey
+     * @param string      $consumerSecret
+     * @param string|null $accessToken
+     * @param string|null $accessTokenSecret
      * @param string|null $apiUrl
-     * @param string|null $proxy
-     * @param $timeout
      */
-    public function __construct($consumerKey, $consumerSecret, $accessToken, $accessTokenSecret, $apiUrl = null, $proxy = null, $timeout = 5)
-    {
+    public function __construct(
+        $consumerKey,
+        $consumerSecret,
+        $accessToken = null,
+        $accessTokenSecret = null,
+        $apiUrl = null
+    ) {
         $this->consumerKey = $consumerKey;
         $this->consumerSecret = $consumerSecret;
         $this->accessToken = $accessToken;
         $this->accessTokenSecret = $accessTokenSecret;
 
         if ($apiUrl) {
-            $this->apiUrl = (string) $apiUrl;
+            $this->apiUrl = $apiUrl;
         }
 
-        $curl = new Curl();
-
-        if ($proxy) {
-            $curl->setProxy($proxy);
-        }
-
-        $curl->setTimeout($timeout);
-        $this->browser = new Browser($curl);
+        $this->browser = new Browser(new Curl());
     }
 
     /**
      * Performs a query to the Twitter API.
      *
-     * @param $name
+     * @param string $name
      * @param string $method
      * @param string $format
      * @param array  $parameters
@@ -88,66 +97,25 @@ class Twitter
      */
     public function query($name, $method = 'GET', $format = 'json', $parameters = array())
     {
-        $oauthParameters = array(
-            'oauth_consumer_key' => $this->consumerKey,
-            'oauth_nonce' => time(),
-            'oauth_signature_method' => 'HMAC-SHA1',
-            'oauth_timestamp' => time(),
-            'oauth_token' => $this->accessToken,
-            'oauth_version' => '1.0',
-        );
-
-        // Part 1 : http method
-        $httpMethod = $method;
-
-        // Part 2 : base url
         $baseUrl = $this->apiUrl.$name.'.'.$format;
 
-        // Part 3 : parameter string
-        $oauthParameters = array_merge($parameters, $oauthParameters);
-        ksort($oauthParameters);
-        $parameterQueryParts = array();
-        foreach ($oauthParameters as $key => $value) {
-            $parameterQueryParts[] = $key.'='.rawurlencode($value);
-        }
-        $parameterString = implode('&', $parameterQueryParts);
-
-        // Build signature string from part 1, 2 and 3
-        $signatureString = strtoupper($httpMethod).'&'.rawurlencode($baseUrl).'&'.rawurlencode($parameterString);
-        $signatureKey = rawurlencode($this->consumerSecret).'&'.rawurlencode($this->accessTokenSecret);
-        $signature = base64_encode(hash_hmac('sha1', $signatureString, $signatureKey, true));
-
-        // Create headers containing oauth
-        $parameterQueryParts[] = 'oauth_signature='.rawurlencode($signature);
-        $oauthHeader = 'OAuth '.implode(', ', $parameterQueryParts);
         $headers = array(
             'Content-Type: application/x-www-form-urlencoded',
-            'Authorization: '.$oauthHeader,
+            'Authorization: '.$this->getAuthorization($baseUrl, $method, $parameters),
         );
 
-        // The call has to be made against the base url + query string
-        if (count($parameters) > 0) {
-            $requestQueryParts = array();
-            foreach ($parameters as $key => $value) {
-                $requestQueryParts[] = $key.'='.rawurlencode($value);
-            }
-            $baseUrl .= '?'.implode('&', $requestQueryParts);
+        $queryParameters = $this->getQueryParameters($parameters);
+        if ($queryParameters) {
+            $baseUrl .= "?$queryParameters";
         }
 
-        // Perform cURL request
-        if (strtoupper($method) == 'GET') {
-            $response = $this->browser->get($baseUrl, $headers);
-        } else {
-            $response = $this->browser->post($baseUrl, $headers);
-        }
-
-        return $response;
+        return $this->call($method, $baseUrl, $headers);
     }
 
     /**
      * Returns the user timeline.
      *
-     * @param $parameters
+     * @param array $parameters
      *
      * @return mixed
      */
@@ -156,5 +124,163 @@ class Twitter
         $response = $this->query('statuses/user_timeline', 'GET', 'json', $parameters);
 
         return json_decode($response->getContent());
+    }
+
+    /**
+     * Returns the header authorization row.
+     *
+     * @param string $baseUrl
+     * @param string $method
+     * @param array  $parameters
+     *
+     * @return string
+     */
+    protected function getAuthorization($baseUrl, $method = 'GET', $parameters = array())
+    {
+        if (!empty($this->accessToken) && !empty($this->accessTokenSecret)) {
+            return $this->getOAuthHeader($baseUrl, $method, $parameters);
+        }
+
+        return $this->getBearerHeader();
+    }
+
+    /**
+     * Returns the header authorization OAuth value.
+     *
+     * @param string $baseUrl
+     * @param string $method
+     * @param array  $parameters
+     *
+     * @return string
+     *
+     * @throws InvalidParametersException
+     */
+    protected function getOAuthHeader($baseUrl, $method = 'GET', $parameters = array())
+    {
+        if (empty($this->accessToken) ||
+            empty($this->accessTokenSecret) ||
+            empty($this->consumerKey) ||
+            empty($this->consumerSecret)
+        ) {
+            $mandatoryParameters = array('accessToken', 'accessTokenSecret', 'consumerKey', 'consumerSecret');
+            throw new InvalidParametersException(
+                sprintf("Twitter needs these mandatory parameters: %s", implode(', ', $mandatoryParameters))
+            );
+        }
+
+        $oAuthParameters = array(
+            'oauth_consumer_key' => $this->consumerKey,
+            'oauth_nonce' => time(),
+            'oauth_signature_method' => 'HMAC-SHA1',
+            'oauth_timestamp' => time(),
+            'oauth_token' => $this->accessToken,
+            'oauth_version' => '1.0',
+        );
+
+        // Build parameters string
+        $oAuthParameters = array_merge($parameters, $oAuthParameters);
+        ksort($oAuthParameters);
+        $queryParameters = $this->getQueryParameters($oAuthParameters);
+        $parameterQueryParts = explode('&', $queryParameters);
+
+        // Build signature string
+        $signatureString = strtoupper($method).'&'.rawurlencode($baseUrl).'&'.rawurlencode($queryParameters);
+        $signatureKey = rawurlencode($this->consumerSecret).'&'.rawurlencode($this->accessTokenSecret);
+        $signature = base64_encode(hash_hmac('sha1', $signatureString, $signatureKey, true));
+
+        // Create headers containing oauth
+        $parameterQueryParts[] = 'oauth_signature='.rawurlencode($signature);
+
+        return 'OAuth '.implode(', ', $parameterQueryParts);
+    }
+
+    /**
+     * Returns the header authorization Bearer value.
+     *
+     * @return string
+     *
+     * @throws InvalidResponseException
+     * @throws InvalidTokenTypeException
+     */
+    public function getBearerHeader()
+    {
+        $headers = array(
+            'Authorization: '.$this->getBasicHeader(),
+            'Content-Type: application/x-www-form-urlencoded'
+        );
+
+        $response = $this->call('POST', self::TOKEN_URL, $headers, 'grant_type=client_credentials');
+        $content = $response->getContent();
+        $result = json_decode($content, true);
+
+        if (!is_array($result) || empty($result['token_type']) || empty($result['access_token'])) {
+            throw new InvalidResponseException(
+                sprintf('Twitter response is invalid: %s', $content)
+            );
+        }
+        if ($result['token_type'] !== 'bearer') {
+            throw new InvalidTokenTypeException(sprintf('Twitter token type is invalid: %s.', $result['token_type']));
+        }
+
+        return 'Bearer '.$result['access_token'];
+    }
+
+    /**
+     * Returns the header authorization Basic value
+     *
+     * @return string
+     *
+     * @throws InvalidParametersException
+     */
+    protected function getBasicHeader()
+    {
+        if (empty($this->consumerKey) || empty($this->consumerSecret)) {
+            $mandatoryParameters = array('consumerKey', 'consumerSecret');
+            throw new InvalidParametersException(
+                sprintf('Twitter needs these mandatory parameters: %s', implode(', ', $mandatoryParameters))
+            );
+        }
+
+        return 'Basic '.base64_encode($this->consumerKey.':'.$this->consumerSecret);
+    }
+
+    /**
+     * Returns the query parameters
+     *
+     * @param array $parameters
+     *
+     * @return string
+     */
+    protected function getQueryParameters($parameters = array())
+    {
+        $query = '';
+        if (count($parameters) > 0) {
+            $queryParts = array();
+            foreach ($parameters as $key => $value) {
+                $queryParts[] = $key.'='.rawurlencode($value);
+            }
+            $query = implode('&', $queryParts);
+        }
+
+        return $query;
+    }
+
+    /**
+     * Calls API through the browser client
+     *
+     * @param $method
+     * @param $baseUrl
+     * @param array $headers
+     * @param string $content
+     *
+     * @return \Buzz\Message\Response
+     */
+    protected function call($method, $baseUrl, $headers = array(), $content = '')
+    {
+        if (strtoupper($method) == 'GET') {
+            return $this->browser->get($baseUrl, $headers);
+        } else {
+            return $this->browser->post($baseUrl, $headers, $content);
+        }
     }
 }

--- a/tests/TwitterTest.php
+++ b/tests/TwitterTest.php
@@ -1,20 +1,171 @@
 <?php
 
-/*
- * (c) Jeroen van den Enden <info@endroid.nl>
- *
- * This source file is subject to the MIT license that is bundled
- * with this source code in the file LICENSE.
- */
+namespace Endroid\Twitter\Tests;
 
-namespace Endroid\Tests\Twitter;
+use Buzz\Message\Response;
+use Endroid\Twitter\Exception\InvalidTokenTypeException;
+use Endroid\Twitter\Twitter;
+use Endroid\Twitter\Exception\InvalidParametersException;
+use Endroid\Twitter\Exception\InvalidResponseException;
 
-use PHPUnit_Framework_TestCase;
-
-class TwitterTest extends PHPUnit_Framework_TestCase
+class TwitterTest extends \PHPUnit_Framework_TestCase
 {
-    public function testNoTestsYet()
+    const EXPECTED_OAUTH_HEADER_PARAMETERS = 'oauth_consumer_key=foo, oauth_nonce=1234567890, oauth_signature_method=HMAC-SHA1, oauth_timestamp=1234567890, oauth_token=baz, oauth_version=1.0';
+    const EXPECTED_OAUTH_HEADER = 'OAuth '.self::EXPECTED_OAUTH_HEADER_PARAMETERS.', oauth_signature=';
+    const EXPECTED_BEARER_HEADER = 'Bearer cc4f26cc4a3f61a84436014b2166e431';
+    const EXPECTED_BASIC_HEADER = 'Basic Zm9vOmJhcg==';
+
+    public function testGetQueryParameters()
     {
-        $this->assertTrue(true);
+        $twitter = new Twitter('foo', 'bar');
+        $parameters = array('a' => 'foo', 'b' => 'bar', 'c' => 'baz');
+        $header = Util::invokeMethod($twitter, 'getQueryParameters', array($parameters));
+        $this->assertEquals('a=foo&b=bar&c=baz', $header);
+    }
+
+    public function testGetBasicHeader()
+    {
+        $twitter = new Twitter('foo', 'bar');
+        $header = Util::invokeMethod($twitter, 'getBasicHeader');
+        $this->assertEquals(self::EXPECTED_BASIC_HEADER, $header);
+    }
+
+    public function testGetBasicHeaderInvalidParametersException()
+    {
+        $twitter = new Twitter(null, null);
+        $this->setExpectedException(InvalidParametersException::class);
+        Util::invokeMethod($twitter, 'getBasicHeader');
+    }
+
+    public function testGetBearerHeader()
+    {
+        $twitter = $this->getMockBuilder(Twitter::class)
+            ->setConstructorArgs(['foo', 'bar'])
+            ->setMethods(['getBasicHeader', 'call'])
+            ->getMock();
+
+        $twitter->expects($this->any())
+            ->method('getBasicHeader')
+            ->willReturn(self::EXPECTED_BASIC_HEADER);
+
+        $response = new Response();
+        $response->setContent(json_encode(array(
+            'token_type' => 'bearer',
+            'access_token' => 'cc4f26cc4a3f61a84436014b2166e431',
+        )));
+
+        $twitter->expects($this->any())
+            ->method('call')
+            ->with('POST', Twitter::TOKEN_URL)
+            ->willReturn($response);
+
+        $header = Util::invokeMethod($twitter, 'getBearerHeader');
+        $this->assertEquals(self::EXPECTED_BEARER_HEADER, $header);
+    }
+
+    public function testGetBearerHeaderInvalidResponseException()
+    {
+        $twitter = $this->getMockBuilder(Twitter::class)
+            ->setConstructorArgs(['foo', 'bar'])
+            ->setMethods(['getBasicHeader', 'call'])
+            ->getMock();
+
+        $twitter->expects($this->any())
+            ->method('getBasicHeader')
+            ->willReturn(self::EXPECTED_BASIC_HEADER);
+
+        $twitter->expects($this->any())
+            ->method('call')
+            ->with('POST', Twitter::TOKEN_URL)
+            ->willReturn(new Response());
+
+        $this->setExpectedException(InvalidResponseException::class);
+        Util::invokeMethod($twitter, 'getBearerHeader');
+    }
+
+    public function testGetBearerHeaderInvalidTokenTypeException()
+    {
+        $twitter = $this->getMockBuilder(Twitter::class)
+            ->setConstructorArgs(['foo', 'bar'])
+            ->setMethods(['getBasicHeader', 'call'])
+            ->getMock();
+
+        $twitter->expects($this->any())
+            ->method('getBasicHeader')
+            ->willReturn(self::EXPECTED_BASIC_HEADER);
+
+        $response = new Response();
+        $response->setContent(json_encode(array(
+            'token_type' => 'something_wrong',
+            'access_token' => 'cc4f26cc4a3f61a84436014b2166e431',
+        )));
+
+        $twitter->expects($this->any())
+            ->method('call')
+            ->with('POST', Twitter::TOKEN_URL)
+            ->willReturn($response);
+
+        $this->setExpectedException(InvalidTokenTypeException::class);
+        Util::invokeMethod($twitter, 'getBearerHeader');
+    }
+
+    public function testGetOAuthHeader()
+    {
+        $twitter = $this->getMockBuilder(Twitter::class)
+            ->setConstructorArgs(['foo', 'bar', 'baz', 'test'])
+            ->setMethods(['getQueryParameters'])
+            ->getMock();
+
+        $twitter->expects($this->any())
+            ->method('getQueryParameters')
+            ->willReturn(self::EXPECTED_OAUTH_HEADER_PARAMETERS);
+
+        $header = Util::invokeMethod($twitter, 'getOAuthHeader', array('https://domain.tld/'));
+        $this->assertContains(self::EXPECTED_OAUTH_HEADER, $header);
+    }
+
+    public function testGetOAuthHeaderInvalidParametersException()
+    {
+        $twitter = new Twitter('foo', 'bar');
+        $this->setExpectedException(InvalidParametersException::class);
+        Util::invokeMethod($twitter, 'getOAuthHeader', array('https://domain.tld/'));
+    }
+
+    public function testGetAuthorizationBearer()
+    {
+        $twitter = $this->getMockBuilder(Twitter::class)
+            ->setConstructorArgs(['foo', 'bar'])
+            ->setMethods(['getOAuthHeader', 'getBearerHeader'])
+            ->getMock();
+
+        $twitter->expects($this->any())
+            ->method('getBearerHeader')
+            ->willReturn(self::EXPECTED_BEARER_HEADER);
+
+        $twitter->expects($this->any())
+            ->method('getOAuthHeader')
+            ->willReturn(self::EXPECTED_OAUTH_HEADER);
+
+        $authorization = Util::invokeMethod($twitter, 'getAuthorization', array('https://domain.tld/'));
+        $this->assertEquals(self::EXPECTED_BEARER_HEADER, $authorization);
+    }
+
+    public function testGetAuthorizationOAuth()
+    {
+        $twitter = $this->getMockBuilder(Twitter::class)
+            ->setConstructorArgs(['foo', 'bar', 'baz', 'test'])
+            ->setMethods(['getOAuthHeader', 'getBearerHeader'])
+            ->getMock();
+
+        $twitter->expects($this->any())
+            ->method('getBearerHeader')
+            ->willReturn(self::EXPECTED_BEARER_HEADER);
+
+        $twitter->expects($this->any())
+            ->method('getOAuthHeader')
+            ->willReturn(self::EXPECTED_OAUTH_HEADER);
+
+        $authorization = Util::invokeMethod($twitter, 'getAuthorization', array('https://domain.tld/'));
+        $this->assertEquals(self::EXPECTED_OAUTH_HEADER, $authorization);
     }
 }

--- a/tests/TwitterTest.php
+++ b/tests/TwitterTest.php
@@ -3,15 +3,12 @@
 namespace Endroid\Twitter\Tests;
 
 use Buzz\Message\Response;
-use Endroid\Twitter\Exception\InvalidTokenTypeException;
 use Endroid\Twitter\Twitter;
-use Endroid\Twitter\Exception\InvalidParametersException;
-use Endroid\Twitter\Exception\InvalidResponseException;
 
 class TwitterTest extends \PHPUnit_Framework_TestCase
 {
     const EXPECTED_OAUTH_HEADER_PARAMETERS = 'oauth_consumer_key=foo, oauth_nonce=1234567890, oauth_signature_method=HMAC-SHA1, oauth_timestamp=1234567890, oauth_token=baz, oauth_version=1.0';
-    const EXPECTED_OAUTH_HEADER = 'OAuth '.self::EXPECTED_OAUTH_HEADER_PARAMETERS.', oauth_signature=';
+    const EXPECTED_OAUTH_HEADER = 'OAuth %s, oauth_signature=';
     const EXPECTED_BEARER_HEADER = 'Bearer cc4f26cc4a3f61a84436014b2166e431';
     const EXPECTED_BASIC_HEADER = 'Basic Zm9vOmJhcg==';
 
@@ -33,15 +30,15 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
     public function testGetBasicHeaderInvalidParametersException()
     {
         $twitter = new Twitter(null, null);
-        $this->setExpectedException(InvalidParametersException::class);
+        $this->setExpectedException('Endroid\Twitter\Exception\InvalidParametersException');
         Util::invokeMethod($twitter, 'getBasicHeader');
     }
 
     public function testGetBearerHeader()
     {
-        $twitter = $this->getMockBuilder(Twitter::class)
-            ->setConstructorArgs(['foo', 'bar'])
-            ->setMethods(['getBasicHeader', 'call'])
+        $twitter = $this->getMockBuilder('Endroid\Twitter\Twitter')
+            ->setConstructorArgs(array('foo', 'bar'))
+            ->setMethods(array('getBasicHeader', 'call'))
             ->getMock();
 
         $twitter->expects($this->any())
@@ -56,7 +53,7 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
 
         $twitter->expects($this->any())
             ->method('call')
-            ->with('POST', Twitter::TOKEN_URL)
+            ->with('POST', Twitter::BASE_URL.Twitter::TOKEN_URL)
             ->willReturn($response);
 
         $header = Util::invokeMethod($twitter, 'getBearerHeader');
@@ -65,9 +62,9 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
 
     public function testGetBearerHeaderInvalidResponseException()
     {
-        $twitter = $this->getMockBuilder(Twitter::class)
-            ->setConstructorArgs(['foo', 'bar'])
-            ->setMethods(['getBasicHeader', 'call'])
+        $twitter = $this->getMockBuilder('Endroid\Twitter\Twitter')
+            ->setConstructorArgs(array('foo', 'bar'))
+            ->setMethods(array('getBasicHeader', 'call'))
             ->getMock();
 
         $twitter->expects($this->any())
@@ -76,18 +73,18 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
 
         $twitter->expects($this->any())
             ->method('call')
-            ->with('POST', Twitter::TOKEN_URL)
+            ->with('POST', Twitter::BASE_URL.Twitter::TOKEN_URL)
             ->willReturn(new Response());
 
-        $this->setExpectedException(InvalidResponseException::class);
+        $this->setExpectedException('Endroid\Twitter\Exception\InvalidResponseException');
         Util::invokeMethod($twitter, 'getBearerHeader');
     }
 
     public function testGetBearerHeaderInvalidTokenTypeException()
     {
-        $twitter = $this->getMockBuilder(Twitter::class)
-            ->setConstructorArgs(['foo', 'bar'])
-            ->setMethods(['getBasicHeader', 'call'])
+        $twitter = $this->getMockBuilder('Endroid\Twitter\Twitter')
+            ->setConstructorArgs(array('foo', 'bar'))
+            ->setMethods(array('getBasicHeader', 'call'))
             ->getMock();
 
         $twitter->expects($this->any())
@@ -102,18 +99,18 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
 
         $twitter->expects($this->any())
             ->method('call')
-            ->with('POST', Twitter::TOKEN_URL)
+            ->with('POST', Twitter::BASE_URL.Twitter::TOKEN_URL)
             ->willReturn($response);
 
-        $this->setExpectedException(InvalidTokenTypeException::class);
+        $this->setExpectedException('Endroid\Twitter\Exception\InvalidTokenTypeException');
         Util::invokeMethod($twitter, 'getBearerHeader');
     }
 
     public function testGetOAuthHeader()
     {
-        $twitter = $this->getMockBuilder(Twitter::class)
-            ->setConstructorArgs(['foo', 'bar', 'baz', 'test'])
-            ->setMethods(['getQueryParameters'])
+        $twitter = $this->getMockBuilder('Endroid\Twitter\Twitter')
+            ->setConstructorArgs(array('foo', 'bar', 'baz', 'test'))
+            ->setMethods(array('getQueryParameters'))
             ->getMock();
 
         $twitter->expects($this->any())
@@ -121,21 +118,21 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
             ->willReturn(self::EXPECTED_OAUTH_HEADER_PARAMETERS);
 
         $header = Util::invokeMethod($twitter, 'getOAuthHeader', array('https://domain.tld/'));
-        $this->assertContains(self::EXPECTED_OAUTH_HEADER, $header);
+        $this->assertContains(sprintf(self::EXPECTED_OAUTH_HEADER, self::EXPECTED_OAUTH_HEADER_PARAMETERS), $header);
     }
 
     public function testGetOAuthHeaderInvalidParametersException()
     {
         $twitter = new Twitter('foo', 'bar');
-        $this->setExpectedException(InvalidParametersException::class);
+        $this->setExpectedException('Endroid\Twitter\Exception\InvalidParametersException');
         Util::invokeMethod($twitter, 'getOAuthHeader', array('https://domain.tld/'));
     }
 
     public function testGetAuthorizationBearer()
     {
-        $twitter = $this->getMockBuilder(Twitter::class)
-            ->setConstructorArgs(['foo', 'bar'])
-            ->setMethods(['getOAuthHeader', 'getBearerHeader'])
+        $twitter = $this->getMockBuilder('Endroid\Twitter\Twitter')
+            ->setConstructorArgs(array('foo', 'bar'))
+            ->setMethods(array('getOAuthHeader', 'getBearerHeader'))
             ->getMock();
 
         $twitter->expects($this->any())
@@ -144,7 +141,7 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
 
         $twitter->expects($this->any())
             ->method('getOAuthHeader')
-            ->willReturn(self::EXPECTED_OAUTH_HEADER);
+            ->willReturn(sprintf(self::EXPECTED_OAUTH_HEADER, self::EXPECTED_OAUTH_HEADER_PARAMETERS));
 
         $authorization = Util::invokeMethod($twitter, 'getAuthorization', array('https://domain.tld/'));
         $this->assertEquals(self::EXPECTED_BEARER_HEADER, $authorization);
@@ -152,9 +149,9 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
 
     public function testGetAuthorizationOAuth()
     {
-        $twitter = $this->getMockBuilder(Twitter::class)
-            ->setConstructorArgs(['foo', 'bar', 'baz', 'test'])
-            ->setMethods(['getOAuthHeader', 'getBearerHeader'])
+        $twitter = $this->getMockBuilder('Endroid\Twitter\Twitter')
+            ->setConstructorArgs(array('foo', 'bar', 'baz', 'test'))
+            ->setMethods(array('getOAuthHeader', 'getBearerHeader'))
             ->getMock();
 
         $twitter->expects($this->any())
@@ -163,9 +160,9 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
 
         $twitter->expects($this->any())
             ->method('getOAuthHeader')
-            ->willReturn(self::EXPECTED_OAUTH_HEADER);
+            ->willReturn(sprintf(self::EXPECTED_OAUTH_HEADER, self::EXPECTED_OAUTH_HEADER_PARAMETERS));
 
         $authorization = Util::invokeMethod($twitter, 'getAuthorization', array('https://domain.tld/'));
-        $this->assertEquals(self::EXPECTED_OAUTH_HEADER, $authorization);
+        $this->assertEquals(sprintf(self::EXPECTED_OAUTH_HEADER, self::EXPECTED_OAUTH_HEADER_PARAMETERS), $authorization);
     }
 }

--- a/tests/Util.php
+++ b/tests/Util.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Endroid\Twitter\Tests;
+
+class Util
+{
+    /**
+     * Call protected/private method of a class.
+     *
+     * @param object &$object    Instantiated object that we will run method on.
+     * @param string $methodName Method name to call
+     * @param array  $parameters Array of parameters to pass into method.
+     *
+     * @return mixed Method return.
+     */
+    public static function invokeMethod(&$object, $methodName, array $parameters = array())
+    {
+        $reflection = new \ReflectionClass(get_class($object));
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $parameters);
+    }
+}


### PR DESCRIPTION
This PR relates with:
- [ ] https://github.com/endroid/EndroidTwitterBundle/pull/7

It adds application-only authentication support to fetch the API without the accessToken and accessTokenSecret parameters.